### PR TITLE
feat: add JSON configuration file support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,8 @@ dependencies = [
  "env_logger",
  "futures-util",
  "log",
+ "serde",
+ "serde_json",
  "tokio",
  "tokio-tungstenite",
 ]
@@ -634,6 +636,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +665,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ futures-util = "0.3"
 log = "0.4"
 env_logger = "0.10"
 anyhow = "1.0"
-
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -36,32 +36,83 @@ MCP Server Runner acts as a bridge between WebSocket clients and MCP server impl
 
 ## Configuration
 
-The application is configured through environment variables:
+### Environment Variables
+
+The application can be configured through environment variables:
 
 ```env
-PROGRAM=        # Path to the MCP server executable (required)
+PROGRAM=        # Path to the MCP server executable (required if no config file)
 ARGS=           # Comma-separated list of arguments for the MCP server
 HOST=0.0.0.0    # Host address to bind to (default: 0.0.0.0)
 PORT=8080       # Port to listen on (default: 8080)
+CONFIG_FILE=    # Path to JSON configuration file
 ```
 
 Additional environment variables will be passed through to the MCP server process.
 
+### JSON Configuration
+
+Alternatively, you can provide a JSON configuration file:
+
+```json
+{
+  "servers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/path/to/workspace"
+      ]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "your_token_here"
+      }
+    }
+  },
+  "default_server": "filesystem",
+  "host": "0.0.0.0",
+  "port": 8080
+}
+```
+
+You can specify the configuration file in two ways:
+
+1. As a command-line argument: `mcp-server-runner config.json`
+2. Using the `CONFIG_FILE` environment variable: `CONFIG_FILE=config.json mcp-server-runner`
+
+The JSON configuration allows you to define multiple server configurations and select one as the default.
+
+### Configuration Priority
+
+1. Command-line specified config file
+2. `CONFIG_FILE` environment variable
+3. Environment variables (`PROGRAM`, `ARGS`, etc.)
+4. Default values
+
 ## Usage
 
-1. Set up the environment variables:
+1. Using environment variables:
 
    ```bash
    export PROGRAM=npx
    export ARGS=-y,@modelcontextprotocol/server-github
    export PORT=8080
    export GITHUB_PERSONAL_ACCESS_TOKEN=github_pat_***
+   cargo run
    ```
 
-2. Run the server:
+2. Using a configuration file:
 
    ```bash
-   cargo run
+   # Either specify the config file as an argument
+   cargo run config.json
+
+   # Or use the CONFIG_FILE environment variable
+   CONFIG_FILE=config.json cargo run
    ```
 
 3. Connect to the WebSocket server:
@@ -102,6 +153,7 @@ RUST_LOG=debug cargo run
 The application follows a modular architecture:
 
 - `main.rs`: Application entry point and server setup
+- `config/`: Configuration loading and management
 - `process/`: Process management and I/O handling
 - `websocket/`: WebSocket connection management
 - `state.rs`: Global state management

--- a/config.json
+++ b/config.json
@@ -1,0 +1,15 @@
+{
+  "servers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "your_token_here"
+      }
+    }
+  },
+  "default_server": "github",
+  "host": "0.0.0.0",
+  "port": 8080
+}
+

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -1,0 +1,114 @@
+use anyhow::{Context, Result};
+use log::{debug, info, warn};
+use std::env;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
+
+use crate::config::model::{Config, ServerConfig};
+
+/// 設定を読み込む
+pub fn load_config(config_path: Option<&str>) -> Result<Config> {
+    // JSONファイルからの設定読み込みを試みる
+    let mut config = if let Some(path) = config_path {
+        load_from_file(path).context("Failed to load config from specified file")?
+    } else if let Ok(path) = env::var("CONFIG_FILE") {
+        load_from_file(&path).context("Failed to load config from CONFIG_FILE environment variable")?
+    } else {
+        debug!("No config file specified, using default config");
+        Config::default()
+    };
+
+    // 環境変数からの設定の上書き
+    merge_env_vars(&mut config);
+
+    validate_config(&config)?;
+    
+    debug!("Loaded config: {:?}", config);
+    Ok(config)
+}
+
+/// ファイルから設定を読み込む
+fn load_from_file<P: AsRef<Path>>(path: P) -> Result<Config> {
+    info!("Loading config from file: {:?}", path.as_ref());
+    let file = File::open(&path)
+        .with_context(|| format!("Failed to open config file: {:?}", path.as_ref()))?;
+    
+    let reader = BufReader::new(file);
+    let config: Config = serde_json::from_reader(reader)
+        .with_context(|| format!("Failed to parse JSON config from: {:?}", path.as_ref()))?;
+    
+    Ok(config)
+}
+
+/// 環境変数から設定を上書きする
+fn merge_env_vars(config: &mut Config) {
+    // ホストとポートの環境変数からの設定
+    if let Ok(host) = env::var("HOST") {
+        config.host = host;
+        debug!("Overriding host from environment variable: {}", config.host);
+    }
+    
+    if let Ok(port_str) = env::var("PORT") {
+        if let Ok(port) = port_str.parse::<u16>() {
+            config.port = port;
+            debug!("Overriding port from environment variable: {}", config.port);
+        } else {
+            warn!("Invalid PORT environment variable: {}", port_str);
+        }
+    }
+
+    // 従来の環境変数からプロセス設定を上書き
+    if let Ok(program) = env::var("PROGRAM") {
+        let args = env::var("ARGS")
+            .unwrap_or_default()
+            .split(',')
+            .map(String::from)
+            .collect::<Vec<_>>();
+        
+        let mut env_vars = std::collections::HashMap::new();
+        for (key, value) in env::vars() {
+            if key != "PROGRAM" && key != "ARGS" && key != "HOST" && key != "PORT" && key != "CONFIG_FILE" {
+                env_vars.insert(key, value);
+            }
+        }
+        
+        // "env" という名前でサーバーを追加
+        config.servers.insert("env".to_string(), ServerConfig {
+            command: program,
+            args,
+            env: env_vars,
+        });
+        
+        // デフォルトサーバーが設定されていない場合、環境変数から設定したサーバーをデフォルトに
+        if config.default_server.is_none() {
+            config.default_server = Some("env".to_string());
+            debug!("Setting default server to 'env' from environment variables");
+        }
+    }
+}
+
+/// 設定の妥当性を検証する
+fn validate_config(config: &Config) -> Result<()> {
+    if config.servers.is_empty() {
+        return Err(anyhow::anyhow!("No server configurations found"));
+    }
+    
+    // デフォルトサーバーが指定されていない場合は先頭のサーバーをデフォルトとする
+    if config.default_server.is_none() && !config.servers.is_empty() {
+        let first_server = config.servers.keys().next().unwrap().clone();
+        warn!("No default server specified, using first server: {}", first_server);
+    }
+    
+    // デフォルトサーバーが存在するか確認
+    if let Some(ref default_server) = config.default_server {
+        if !config.servers.contains_key(default_server) {
+            return Err(anyhow::anyhow!(
+                "Default server '{}' not found in server configurations",
+                default_server
+            ));
+        }
+    }
+    
+    Ok(())
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,4 @@
+pub mod model;
+mod loader;
+
+pub use loader::load_config;

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -1,0 +1,88 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// サーバー設定全体を表す構造体
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Config {
+    /// 利用可能なサーバー設定のマップ
+    pub servers: HashMap<String, ServerConfig>,
+    /// デフォルトで使用するサーバー名
+    #[serde(default)]
+    pub default_server: Option<String>,
+    /// WebSocketサーバーのホスト（デフォルト: "0.0.0.0"）
+    #[serde(default = "default_host")]
+    pub host: String,
+    /// WebSocketサーバーのポート（デフォルト: 8080）
+    #[serde(default = "default_port")]
+    pub port: u16,
+}
+
+/// 個別のサーバー設定を表す構造体
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerConfig {
+    /// 実行するコマンド
+    pub command: String,
+    /// コマンドに渡す引数
+    #[serde(default)]
+    pub args: Vec<String>,
+    /// プロセスに渡す環境変数
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+}
+
+fn default_host() -> String {
+    "0.0.0.0".to_string()
+}
+
+fn default_port() -> u16 {
+    8080
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            servers: HashMap::new(),
+            default_server: None,
+            host: default_host(),
+            port: default_port(),
+        }
+    }
+}
+
+/// 設定ファイルの例
+pub fn example_config() -> Config {
+    let mut servers = HashMap::new();
+    
+    // filesystem サーバーの設定
+    let filesystem_server = ServerConfig {
+        command: "npx".to_string(),
+        args: vec![
+            "-y".to_string(),
+            "@modelcontextprotocol/server-filesystem".to_string(),
+            "/Users/yonaka/workspace".to_string(),
+            "/Users/yonaka/mcp-servers".to_string(),
+        ],
+        env: HashMap::new(),
+    };
+    
+    // github サーバーの設定
+    let mut github_server = ServerConfig {
+        command: "npx".to_string(),
+        args: vec![
+            "-y".to_string(),
+            "@modelcontextprotocol/server-github".to_string(),
+        ],
+        env: HashMap::new(),
+    };
+    github_server.env.insert("GITHUB_PERSONAL_ACCESS_TOKEN".to_string(), "token_value".to_string());
+    
+    servers.insert("filesystem".to_string(), filesystem_server);
+    servers.insert("github".to_string(), github_server);
+    
+    Config {
+        servers,
+        default_server: Some("filesystem".to_string()),
+        host: "0.0.0.0".to_string(),
+        port: 8080,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod config;
 mod constants;
 mod process;
 mod shutdown;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,13 @@
-use anyhow::{Context, Result};
+use anyhow::{Result};
 use log::{debug, error, info, warn};
 use std::env;
+use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use tokio::net::TcpListener;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
 
 use mcp_server_runner::{
+    config::{self, model::ServerConfig},
     handle_connection, shutdown_signal, ProcessManager, CONNECTED, MESSAGE_BUFFER_SIZE, SHUTDOWN,
 };
 
@@ -16,68 +18,102 @@ async fn main() -> Result<()> {
         .format_target(true)
         .init();
 
-    let program = env::var("PROGRAM").context("PROGRAM environment variable not set")?;
-    let args = env::var("ARGS")
-        .unwrap_or_default()
-        .split(',')
-        .map(String::from)
-        .collect::<Vec<_>>();
+    // コマンドライン引数を解析
+    let args: Vec<String> = env::args().collect();
+    let config_path = args.iter().skip(1).next().map(|s| s.as_str());
 
-    let env_vars: Vec<(String, String)> = env::vars()
-        .filter(|(key, _)| key != "PROGRAM" && key != "ARGS")
-        .collect();
+    // 設定の読み込み
+    let config = config::load_config(config_path)?;
 
-    let host = env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
-    let port = env::var("PORT").unwrap_or_else(|_| "8080".to_string());
+    // デフォルトサーバー設定の取得（所有権を取得してクローン）
+    let default_server = config.default_server.clone()
+        .and_then(|server_name| config.servers.get(&server_name).cloned())
+        .ok_or_else(|| anyhow::anyhow!("No default server configuration found"))?;
 
-    let addr = format!("{}:{}", host, port);
-
+    let addr = format!("{}:{}", config.host, config.port);
     let listener = TcpListener::bind(&addr).await?;
     info!(
-        "WebSocket server started: {} (Program: {}, Args: {:?})",
-        &addr, program, args
+        "WebSocket server started on {} (Default server: {})",
+        &addr,
+        config.default_server.as_ref().unwrap_or(&"unknown".to_string())
     );
 
-    let mut process_manager = ProcessManager::new();
+    // WebSocketサーバーとプロセス管理の設定 - Arcで共有可能にする
+    let process_manager = Arc::new(Mutex::new(ProcessManager::new()));
     debug!("Process manager initialized");
 
     let shutdown_handle = tokio::spawn(shutdown_signal());
     debug!("Shutdown handler initialized");
 
-    let server = async {
-        while let Ok((stream, addr)) = listener.accept().await {
-            if SHUTDOWN.load(Ordering::SeqCst) {
-                info!("Shutdown signal received, stopping server");
-                break;
+    // サーバーループを起動（実際のサーバータスクを作成）
+    let manager_clone = Arc::clone(&process_manager);
+    let server_task = tokio::spawn(async move {
+        run_server(
+            listener, 
+            manager_clone,
+            default_server,
+        ).await
+    });
+
+    // シャットダウンハンドラーとサーバーのいずれかが終了したら、全体をシャットダウン
+    tokio::select! {
+        result = server_task => {
+            match result {
+                Ok(Ok(())) => debug!("Server loop terminated normally"),
+                Ok(Err(e)) => error!("Server loop terminated with error: {}", e),
+                Err(e) => error!("Server task failed: {}", e),
             }
+        },
+        _ = shutdown_handle => {
+            info!("Initiating shutdown sequence...");
+            let mut pm = process_manager.lock().await;
+            pm.shutdown().await;
+            info!("Shutdown complete");
+        }
+    }
 
-            if CONNECTED.load(Ordering::SeqCst) {
-                warn!(
-                    "Connection rejected: Already have an active connection from: {}",
-                    addr
-                );
-                continue;
-            }
+    Ok(())
+}
 
-            info!("New client connection accepted: {}", addr);
-            debug!(
-                "Client connection details - Local addr: {:?}, Peer addr: {:?}",
-                stream.local_addr(),
-                stream.peer_addr()
+/// WebSocketサーバーのメインループを実行
+async fn run_server(
+    listener: TcpListener,
+    process_manager: Arc<Mutex<ProcessManager>>,
+    server_config: ServerConfig,
+) -> Result<()> {
+    while let Ok((stream, addr)) = listener.accept().await {
+        if SHUTDOWN.load(Ordering::SeqCst) {
+            info!("Shutdown signal received, stopping server");
+            break;
+        }
+
+        if CONNECTED.load(Ordering::SeqCst) {
+            warn!(
+                "Connection rejected: Already have an active connection from: {}",
+                addr
             );
+            continue;
+        }
 
-            let (ws_tx, ws_rx) = mpsc::channel(MESSAGE_BUFFER_SIZE);
-            debug!(
-                "Created message channels with buffer size: {}",
-                MESSAGE_BUFFER_SIZE
-            );
+        info!("New client connection accepted: {}", addr);
+        debug!(
+            "Client connection details - Local addr: {:?}, Peer addr: {:?}",
+            stream.local_addr(),
+            stream.peer_addr()
+        );
 
-            let process_tx = match process_manager
-                .start_process(&program, &args, &env_vars, ws_tx.clone())
-                .await
-            {
+        let (ws_tx, ws_rx) = mpsc::channel(MESSAGE_BUFFER_SIZE);
+        debug!(
+            "Created message channels with buffer size: {}",
+            MESSAGE_BUFFER_SIZE
+        );
+
+        // プロセスを起動
+        let process_tx = {
+            let mut pm = process_manager.lock().await;
+            match pm.start_process(&server_config.command, &server_config.args, &server_config.env, ws_tx.clone()).await {
                 Ok(tx) => {
-                    info!("Successfully started child process");
+                    info!("Successfully started child process: {}", server_config.command);
                     tx
                 }
                 Err(e) => {
@@ -87,23 +123,12 @@ async fn main() -> Result<()> {
                     );
                     continue;
                 }
-            };
+            }
+        };
 
-            debug!("Spawning connection handler for client: {}", addr);
-            tokio::spawn(handle_connection(stream, process_tx, ws_rx));
-            info!("Connection handler spawned for client: {}", addr);
-        }
-    };
-
-    tokio::select! {
-        _ = server => {
-            debug!("Server loop terminated");
-        },
-        _ = shutdown_handle => {
-            info!("Initiating shutdown sequence...");
-            process_manager.shutdown().await;
-            info!("Shutdown complete");
-        }
+        debug!("Spawning connection handler for client: {}", addr);
+        tokio::spawn(handle_connection(stream, process_tx, ws_rx));
+        info!("Connection handler spawned for client: {}", addr);
     }
 
     Ok(())

--- a/src/process/manager.rs
+++ b/src/process/manager.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use log::{debug, error};
+use std::collections::HashMap;
 use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
 
@@ -19,7 +20,7 @@ impl ProcessManager {
         &mut self,
         program: &str,
         args: &[String],
-        env_vars: &Vec<(String, String)>,
+        env_vars: &HashMap<String, String>,
         websocket_tx: mpsc::Sender<String>,
     ) -> Result<mpsc::Sender<String>> {
         let child = self.spawn_process(program, args, env_vars)?;
@@ -34,9 +35,10 @@ impl ProcessManager {
         &mut self,
         program: &str,
         args: &[String],
-        env_vars: &Vec<(String, String)>,
+        env_vars: &HashMap<String, String>,
     ) -> Result<Child> {
         let mut command = Command::new(program);
+        
         if !args.is_empty() {
             command.args(args);
         }
@@ -45,6 +47,8 @@ impl ProcessManager {
             command.env(key, value);
         }
 
+        debug!("Spawning process: {} {:?}", program, args);
+        
         let child = command
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())


### PR DESCRIPTION
- Add support for configuring server via JSON files
- Allow multiple server configurations in a single config file
- Enable specifying config file via command-line argument or environment variable
- Maintain backward compatibility with existing environment variable configuration
- Improve process management with tokio::sync::Mutex for thread safety
- Update documentation with new configuration options